### PR TITLE
Expose implementations of platform specific identities

### DIFF
--- a/pkg/broker/user_info.go
+++ b/pkg/broker/user_info.go
@@ -1,0 +1,93 @@
+package broker
+
+import (
+	"encoding/json"
+	"fmt"
+
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+)
+
+// parseKubernetesIdentity - creates a kubernetes identity from the
+// orginating identity
+func parseKubernetesIdentity(o osb.OriginatingIdentity) (*KubernetesUserInfo, error) {
+	u := KubernetesUserInfo{}
+	err := json.Unmarshal([]byte(o.Value), &u)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal json for value while parsing Kubernetes identity")
+	}
+	return &u, nil
+}
+
+// parseCloudFoundryIdentity - creates a cloud foundry identity from the
+// orginating identity
+func parseCloudFoundryIdentity(o osb.OriginatingIdentity) (*CloudFoundryUserInfo, error) {
+	m := map[string]interface{}{}
+	err := json.Unmarshal([]byte(o.Value), &m)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal json for value while parsing cloud foundry identity")
+	}
+	// Validate that user_id MUST be in the json object.
+	var u interface{}
+	var user string
+	var ok bool
+	if u, ok = m["user_id"]; !ok {
+		return nil, fmt.Errorf("user_id key was not found in cloud foundry object")
+	}
+	user, ok = u.(string)
+	if !ok {
+		return nil, fmt.Errorf("user_id value was not a string in cloud foundry object")
+	}
+	delete(m, "user_id")
+	c := CloudFoundryUserInfo{UserID: user, Extras: m}
+	return &c, nil
+}
+
+// ParseIdentity - retrieve the identity union type
+func ParseIdentity(o osb.OriginatingIdentity) (Identity, error) {
+	identity := Identity{Platform: o.Platform}
+	switch o.Platform {
+	case osb.PlatformKubernetes:
+		k, err := parseKubernetesIdentity(o)
+		if err != nil {
+			return identity, err
+		}
+		identity.Kubernetes = k
+	case osb.PlatformCloudFoundry:
+		c, err := parseCloudFoundryIdentity(o)
+		if err != nil {
+			return identity, err
+		}
+		identity.CloudFoundry = c
+	default:
+		m := map[string]interface{}{}
+		err := json.Unmarshal([]byte(o.Value), &m)
+		if err != nil {
+			return identity, fmt.Errorf("unable to unmarshal json for value")
+		}
+		identity.Unknown = m
+	}
+	return identity, nil
+}
+
+// Identity - union type, used to access the correct originating identity
+// implementation type
+type Identity struct {
+	Platform     string
+	Kubernetes   *KubernetesUserInfo
+	CloudFoundry *CloudFoundryUserInfo
+	Unknown      map[string]interface{}
+}
+
+// KubernetesUserInfo - kubernetes user info object
+type KubernetesUserInfo struct {
+	Username string              `json:"username"`
+	UID      string              `json:"uid"`
+	Groups   []string            `json:"groups"`
+	Extra    map[string][]string `json:"extra"`
+}
+
+// CloudFoundryUserInfo - cloud foundry user info object
+type CloudFoundryUserInfo struct {
+	UserID string
+	Extras map[string]interface{}
+}

--- a/pkg/broker/user_info_test.go
+++ b/pkg/broker/user_info_test.go
@@ -1,0 +1,108 @@
+package broker
+
+import (
+	"reflect"
+	"testing"
+
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+)
+
+func TestParseIdentity(t *testing.T) {
+	cases := []struct {
+		name              string
+		o                 osb.OriginatingIdentity
+		shouldErr         bool
+		expectingIdentity Identity
+	}{
+		{
+			name: "kubernetes invalid value json",
+			o: osb.OriginatingIdentity{
+				Platform: osb.PlatformKubernetes,
+				Value:    `{ser_id": "123"}`,
+			},
+			shouldErr: true,
+		},
+		{
+			name: "kubernetes valid identity",
+			o: osb.OriginatingIdentity{
+				Platform: osb.PlatformKubernetes,
+				Value:    `{"username": "foo", "groups":[], "extra": {}}`,
+			},
+			expectingIdentity: Identity{
+				Platform: "kubernetes",
+				Kubernetes: &KubernetesUserInfo{
+					Username: "foo",
+					Groups:   []string{},
+					Extra:    map[string][]string{},
+				},
+			},
+		},
+		{
+			name: "cloud foundry invalid value json",
+			o: osb.OriginatingIdentity{
+				Platform: "cloudfoundry",
+				Value:    `{ser_id": "123"}`,
+			},
+			shouldErr: true,
+		},
+		{
+			name: "cloud foundry no user_id",
+			o: osb.OriginatingIdentity{
+				Platform: "cloudfoundry",
+				Value:    `{"username": "123"}`,
+			},
+			shouldErr: true,
+		},
+		{
+			name: "cloud foundry invalid user_id",
+			o: osb.OriginatingIdentity{
+				Platform: "cloudfoundry",
+				Value:    `{"username": 123}`,
+			},
+			shouldErr: true,
+		},
+		{
+			name: "cloud foundry valid identity",
+			o: osb.OriginatingIdentity{
+				Platform: "cloudfoundry",
+				Value:    `{"user_id": "123"}`,
+			},
+			expectingIdentity: Identity{
+				Platform: "cloudfoundry",
+				CloudFoundry: &CloudFoundryUserInfo{
+					UserID: "123",
+					Extras: map[string]interface{}{},
+				},
+			},
+		},
+		{
+			name: "unknown identity",
+			o: osb.OriginatingIdentity{
+				Platform: "Unknown",
+				Value:    `{"user_id": "123"}`,
+			},
+			expectingIdentity: Identity{
+				Platform: "Unknown",
+				Unknown: map[string]interface{}{
+					"user_id": "123",
+				},
+			},
+		},
+	}
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := ParseIdentity(tc.o)
+			if err != nil {
+				if tc.shouldErr {
+					return
+				}
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+			if !reflect.DeepEqual(tc.expectingIdentity, actual) {
+				t.Errorf("Unexpected response\n\nExpecting identity:%#+v\nGot: %#+v", tc.expectingIdentity, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently putting this into the broker package, I thought this was an okay place because callers already need to import the broker package to get the request context struct. Implementation is based on the [spec definition](https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#originating-identity-header).
(edit: including the link to OSB API Definitions)