### PR TITLE
fixes 8 - use r.FormValue to access query params

### DIFF
--- a/pkg/rest/apisurface.go
+++ b/pkg/rest/apisurface.go
@@ -172,10 +172,10 @@ func unpackDeprovisionRequest(r *http.Request) (*osb.DeprovisionRequest, error) 
 
 	vars := mux.Vars(r)
 	osbRequest.InstanceID = vars[osb.VarKeyInstanceID]
-	osbRequest.ServiceID = vars[osb.VarKeyServiceID]
-	osbRequest.PlanID = vars[osb.VarKeyPlanID]
+	osbRequest.ServiceID = r.FormValue(osb.VarKeyServiceID)
+	osbRequest.PlanID = r.FormValue(osb.VarKeyPlanID)
 
-	asyncQueryParamVal := r.URL.Query().Get(osb.AcceptsIncomplete)
+	asyncQueryParamVal := r.FormValue(osb.AcceptsIncomplete)
 	if strings.ToLower(asyncQueryParamVal) == "true" {
 		osbRequest.AcceptsIncomplete = true
 	}

--- a/pkg/server/deprovision_test.go
+++ b/pkg/server/deprovision_test.go
@@ -45,6 +45,16 @@ func TestDeprovision(t *testing.T) {
 			},
 		},
 		{
+			name: "deprovision validate incoming parameters",
+			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
+				if req.PlanID == "" {
+					return nil, errors.New("deprovision request missing plan_id query parameter")
+				}
+				return &osb.DeprovisionResponse{}, nil
+			},
+			response: &osb.DeprovisionResponse{},
+		},
+		{
 			name: "deprovision returns osb.HTTPStatusCodeError",
 			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
 				return nil, osb.HTTPStatusCodeError{


### PR DESCRIPTION
This only fixes the specific case of deprovision. There are other cases
where we are using vars[key] for query parameters which is incorrect.