### PR TITLE
Test that requests are correctly deserialized into client types

### DIFF
--- a/pkg/server/deprovision_test.go
+++ b/pkg/server/deprovision_test.go
@@ -35,7 +35,7 @@ func TestDeprovision(t *testing.T) {
 			},
 		},
 		{
-			name: "deprovision returns errors.New",
+			name: "returns errors.New",
 			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
 				return nil, errors.New("oops")
 			},
@@ -45,7 +45,7 @@ func TestDeprovision(t *testing.T) {
 			},
 		},
 		{
-			name: "deprovision validate incoming parameters",
+			name: "validate incoming parameters",
 			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
 				if req.PlanID == "" {
 					return nil, errors.New("deprovision request missing plan_id query parameter")
@@ -55,7 +55,7 @@ func TestDeprovision(t *testing.T) {
 			response: &osb.DeprovisionResponse{},
 		},
 		{
-			name: "deprovision returns osb.HTTPStatusCodeError",
+			name: "returns osb.HTTPStatusCodeError",
 			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
 				return nil, osb.HTTPStatusCodeError{
 					StatusCode:  http.StatusBadGateway,
@@ -68,14 +68,14 @@ func TestDeprovision(t *testing.T) {
 			},
 		},
 		{
-			name: "deprovision returns sync",
+			name: "returns sync",
 			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
 				return &osb.DeprovisionResponse{}, nil
 			},
 			response: &osb.DeprovisionResponse{},
 		},
 		{
-			name: "deprovision returns async",
+			name: "returns async",
 			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
 				return &osb.DeprovisionResponse{
 					Async: true,
@@ -86,7 +86,7 @@ func TestDeprovision(t *testing.T) {
 			},
 		},
 		{
-			name: "deprovision check originating origin idenity is passed",
+			name: "check originating origin identity is passed",
 			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
 				if req.OriginatingIdentity != nil {
 					return &osb.DeprovisionResponse{
@@ -114,10 +114,27 @@ func TestDeprovision(t *testing.T) {
 			osbMetrics := metrics.New()
 			reg.MustRegister(osbMetrics)
 
+			request := &osb.DeprovisionRequest{
+				InstanceID:          "12345",
+				ServiceID:           "12345",
+				PlanID:              "12345",
+				AcceptsIncomplete:   true,
+				OriginatingIdentity: originatingIdentity(),
+			}
+
+			// establish that the request we got was the request we sent
+			deprovisionFunc := func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
+				if !reflect.DeepEqual(request, req) {
+					t.Errorf("unexpected request; expected %v, got %v", request, req)
+				}
+
+				return tc.deprovisionFunc(req, c)
+			}
+
 			api := &rest.APISurface{
 				BusinessLogic: &FakeBusinessLogic{
 					validateAPIVersion: validateFunc,
-					deprovision:        tc.deprovisionFunc,
+					deprovision:        deprovisionFunc,
 				},
 				Metrics: osbMetrics,
 			}
@@ -133,18 +150,8 @@ func TestDeprovision(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			o := osb.OriginatingIdentity{
-				Platform: "kubernetes",
-				Value:    `{"username":"test", "groups": [], "extra": {}}`,
-			}
 
-			actualResponse, err := client.DeprovisionInstance(&osb.DeprovisionRequest{
-				InstanceID:          "12345",
-				ServiceID:           "12345",
-				PlanID:              "12345",
-				AcceptsIncomplete:   true,
-				OriginatingIdentity: &o,
-			})
+			actualResponse, err := client.DeprovisionInstance(request)
 			if err != nil {
 				if tc.err != nil {
 					if e, a := tc.err, err; !reflect.DeepEqual(e, a) {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -34,7 +34,7 @@ func TestProvision(t *testing.T) {
 			},
 		},
 		{
-			name: "provision returns errors.New",
+			name: "returns errors.New",
 			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
 				return nil, errors.New("oops")
 			},
@@ -44,7 +44,7 @@ func TestProvision(t *testing.T) {
 			},
 		},
 		{
-			name: "provision returns osb.HTTPStatusCodeError",
+			name: "returns osb.HTTPStatusCodeError",
 			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
 				return nil, osb.HTTPStatusCodeError{
 					StatusCode:  http.StatusBadGateway,
@@ -57,7 +57,7 @@ func TestProvision(t *testing.T) {
 			},
 		},
 		{
-			name: "provision returns sync",
+			name: "returns sync",
 			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
 				return &osb.ProvisionResponse{
 					DashboardURL: strPtr("my.service.to/12345"),
@@ -68,7 +68,7 @@ func TestProvision(t *testing.T) {
 			},
 		},
 		{
-			name: "provision returns async",
+			name: "returns async",
 			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
 				return &osb.ProvisionResponse{
 					Async:        true,
@@ -81,7 +81,7 @@ func TestProvision(t *testing.T) {
 			},
 		},
 		{
-			name: "provision check originating origin identity is passed",
+			name: "check originating origin identity is passed",
 			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
 				if req.OriginatingIdentity != nil {
 
@@ -112,10 +112,29 @@ func TestProvision(t *testing.T) {
 			osbMetrics := metrics.New()
 			reg.MustRegister(osbMetrics)
 
+			request := &osb.ProvisionRequest{
+				InstanceID:          "12345",
+				ServiceID:           "12345",
+				PlanID:              "12345",
+				OrganizationGUID:    "12345",
+				SpaceGUID:           "12345",
+				AcceptsIncomplete:   true,
+				OriginatingIdentity: originatingIdentity(),
+			}
+
+			// establish that the request we got was the request we sent
+			provisionFunc := func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
+				if !reflect.DeepEqual(request, req) {
+					t.Errorf("unexpected request; expected %v, got %v", request, req)
+				}
+
+				return tc.provisionFunc(req, c)
+			}
+
 			api := &rest.APISurface{
 				BusinessLogic: &FakeBusinessLogic{
 					validateAPIVersion: validateFunc,
-					provision:          tc.provisionFunc,
+					provision:          provisionFunc,
 				},
 				Metrics: osbMetrics,
 			}
@@ -132,20 +151,7 @@ func TestProvision(t *testing.T) {
 				t.Error(err)
 			}
 
-			o := osb.OriginatingIdentity{
-				Platform: "kubernetes",
-				Value:    `{"username":"test", "groups": [], "extra": {}}`,
-			}
-
-			actualResponse, err := client.ProvisionInstance(&osb.ProvisionRequest{
-				InstanceID:          "12345",
-				ServiceID:           "12345",
-				PlanID:              "12345",
-				OrganizationGUID:    "12345",
-				SpaceGUID:           "12345",
-				AcceptsIncomplete:   true,
-				OriginatingIdentity: &o,
-			})
+			actualResponse, err := client.ProvisionInstance(request)
 			if err != nil {
 				if tc.err != nil {
 					if e, a := tc.err, err; !reflect.DeepEqual(e, a) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -69,3 +69,10 @@ func defaultClientConfiguration() *osb.ClientConfiguration {
 
 	return conf
 }
+
+func originatingIdentity() *osb.OriginatingIdentity {
+	return &osb.OriginatingIdentity{
+		Platform: "kubernetes",
+		Value:    `{"username":"test", "groups": [], "extra": {}}`,
+	}
+}


### PR DESCRIPTION
Improves tests for deprovision and provision by adding a check that the request sent to the client is deep equal to the one received.