### PR TITLE
rename BusinessLogic to Interface

### DIFF
--- a/pkg/broker/interface.go
+++ b/pkg/broker/interface.go
@@ -6,10 +6,10 @@ import (
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
 )
 
-// BusinessLogic contains the business logic for the broker's operations.
-// BusinessLogic is the interface broker authors should implement and is
+// Interface contains the business logic for the broker's operations.
+// Interface is the interface broker authors should implement and is
 // embedded in an APISurface.
-type BusinessLogic interface {
+type Interface interface {
 	// ValidateBrokerAPIVersion encapsulates the business logic of validating
 	// the OSB API version sent to the broker with every request and returns
 	// an error.

--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -3,9 +3,9 @@
 //
 // Main components of this library are:
 //
-// - broker/BusinessLogic: the interface containing the callbacks for the OSB
+// - broker/Interface: the interface containing the callbacks for the OSB
 //   API actions
 // - rest/APISurface: provides the glue between the OSB REST API and
-//   your BusinessLogic
+//   your broker.Interface
 // - server/Server: the HTTP server for the OSB and metrics APIs
 package pkg

--- a/pkg/rest/apisurface.go
+++ b/pkg/rest/apisurface.go
@@ -21,29 +21,29 @@ import (
 // the broker's internal business logic into the correct places in the HTTP
 // response.
 type APISurface struct {
-	// BusinessLogic contains the business logic that provides the
+	// Broker contains the business logic that provides the
 	// implementation for the different OSB API operations.
-	BusinessLogic broker.BusinessLogic
-	Metrics       *metrics.OSBMetricsCollector
+	Broker  broker.Interface
+	Metrics *metrics.OSBMetricsCollector
 }
 
 // NewAPISurface returns a new, ready-to-go APISurface.
-func NewAPISurface(businessLogic broker.BusinessLogic, m *metrics.OSBMetricsCollector) (*APISurface, error) {
+func NewAPISurface(brokerInterface broker.Interface, m *metrics.OSBMetricsCollector) (*APISurface, error) {
 	api := &APISurface{
-		BusinessLogic: businessLogic,
-		Metrics:       m,
+		Broker:  brokerInterface,
+		Metrics: m,
 	}
 
 	return api, nil
 }
 
 // GetCatalogHandler is the mux handler that dispatches requests to get the
-// broker's catalog to the broker's BusinessLogic.
+// broker's catalog to the broker's Interface.
 func (s *APISurface) GetCatalogHandler(w http.ResponseWriter, r *http.Request) {
 	s.Metrics.Actions.WithLabelValues("get_catalog").Inc()
 
 	version := getBrokerAPIVersionFromRequest(r)
-	if err := s.BusinessLogic.ValidateBrokerAPIVersion(version); err != nil {
+	if err := s.Broker.ValidateBrokerAPIVersion(version); err != nil {
 		writeError(w, err, http.StatusPreconditionFailed)
 		return
 	}
@@ -53,7 +53,7 @@ func (s *APISurface) GetCatalogHandler(w http.ResponseWriter, r *http.Request) {
 		Request: r,
 	}
 
-	response, err := s.BusinessLogic.GetCatalog(c)
+	response, err := s.Broker.GetCatalog(c)
 	if err != nil {
 		writeError(w, err, http.StatusInternalServerError)
 		return
@@ -63,12 +63,12 @@ func (s *APISurface) GetCatalogHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // ProvisionHandler is the mux handler that dispatches ProvisionRequests to the
-// broker's BusinessLogic.
+// broker's Interface.
 func (s *APISurface) ProvisionHandler(w http.ResponseWriter, r *http.Request) {
 	s.Metrics.Actions.WithLabelValues("provision").Inc()
 
 	version := getBrokerAPIVersionFromRequest(r)
-	if err := s.BusinessLogic.ValidateBrokerAPIVersion(version); err != nil {
+	if err := s.Broker.ValidateBrokerAPIVersion(version); err != nil {
 		writeError(w, err, http.StatusPreconditionFailed)
 		return
 	}
@@ -86,7 +86,7 @@ func (s *APISurface) ProvisionHandler(w http.ResponseWriter, r *http.Request) {
 		Request: r,
 	}
 
-	response, err := s.BusinessLogic.Provision(request, c)
+	response, err := s.Broker.Provision(request, c)
 	if err != nil {
 		writeError(w, err, http.StatusInternalServerError)
 		return
@@ -129,12 +129,12 @@ func unpackProvisionRequest(r *http.Request) (*osb.ProvisionRequest, error) {
 }
 
 // DeprovisionHandler is the mux handler that dispatches deprovision requests to
-// the broker's BusinessLogic.
+// the broker's Interface.
 func (s *APISurface) DeprovisionHandler(w http.ResponseWriter, r *http.Request) {
 	s.Metrics.Actions.WithLabelValues("deprovision").Inc()
 
 	version := getBrokerAPIVersionFromRequest(r)
-	if err := s.BusinessLogic.ValidateBrokerAPIVersion(version); err != nil {
+	if err := s.Broker.ValidateBrokerAPIVersion(version); err != nil {
 		writeError(w, err, http.StatusPreconditionFailed)
 		return
 	}
@@ -152,7 +152,7 @@ func (s *APISurface) DeprovisionHandler(w http.ResponseWriter, r *http.Request) 
 		Request: r,
 	}
 
-	response, err := s.BusinessLogic.Deprovision(request, c)
+	response, err := s.Broker.Deprovision(request, c)
 	if err != nil {
 		writeError(w, err, http.StatusInternalServerError)
 		return
@@ -189,12 +189,12 @@ func unpackDeprovisionRequest(r *http.Request) (*osb.DeprovisionRequest, error) 
 }
 
 // LastOperationHandler is the mux handler that dispatches last-operation
-// requests to the broker's BusinessLogic.
+// requests to the broker's Interface.
 func (s *APISurface) LastOperationHandler(w http.ResponseWriter, r *http.Request) {
 	s.Metrics.Actions.WithLabelValues("last_operation").Inc()
 
 	version := getBrokerAPIVersionFromRequest(r)
-	if err := s.BusinessLogic.ValidateBrokerAPIVersion(version); err != nil {
+	if err := s.Broker.ValidateBrokerAPIVersion(version); err != nil {
 		writeError(w, err, http.StatusPreconditionFailed)
 		return
 	}
@@ -214,7 +214,7 @@ func (s *APISurface) LastOperationHandler(w http.ResponseWriter, r *http.Request
 		Request: r,
 	}
 
-	response, err := s.BusinessLogic.LastOperation(request, c)
+	response, err := s.Broker.LastOperation(request, c)
 	if err != nil {
 		// TODO: This should return a 400 in this case as it is either
 		// malformed or missing mandatory data, as per the OSB spec.
@@ -248,12 +248,12 @@ func unpackLastOperationRequest(r *http.Request) (*osb.LastOperationRequest, err
 }
 
 // BindHandler is the mux handler that dispatches bind requests to the broker's
-// BusinessLogic.
+// Interface.
 func (s *APISurface) BindHandler(w http.ResponseWriter, r *http.Request) {
 	s.Metrics.Actions.WithLabelValues("bind").Inc()
 
 	version := getBrokerAPIVersionFromRequest(r)
-	if err := s.BusinessLogic.ValidateBrokerAPIVersion(version); err != nil {
+	if err := s.Broker.ValidateBrokerAPIVersion(version); err != nil {
 		writeError(w, err, http.StatusPreconditionFailed)
 		return
 	}
@@ -271,7 +271,7 @@ func (s *APISurface) BindHandler(w http.ResponseWriter, r *http.Request) {
 		Request: r,
 	}
 
-	response, err := s.BusinessLogic.Bind(request, c)
+	response, err := s.Broker.Bind(request, c)
 	if err != nil {
 		writeError(w, err, http.StatusInternalServerError)
 		return
@@ -301,12 +301,12 @@ func unpackBindRequest(r *http.Request) (*osb.BindRequest, error) {
 }
 
 // UnbindHandler is the mux handler that dispatches unbind requests to the
-// broker's BusinessLogic.
+// broker's Interface.
 func (s *APISurface) UnbindHandler(w http.ResponseWriter, r *http.Request) {
 	s.Metrics.Actions.WithLabelValues("unbind").Inc()
 
 	version := getBrokerAPIVersionFromRequest(r)
-	if err := s.BusinessLogic.ValidateBrokerAPIVersion(version); err != nil {
+	if err := s.Broker.ValidateBrokerAPIVersion(version); err != nil {
 		writeError(w, err, http.StatusPreconditionFailed)
 		return
 	}
@@ -323,7 +323,7 @@ func (s *APISurface) UnbindHandler(w http.ResponseWriter, r *http.Request) {
 		Request: r,
 	}
 
-	response, err := s.BusinessLogic.Unbind(request, c)
+	response, err := s.Broker.Unbind(request, c)
 	if err != nil {
 		writeError(w, err, http.StatusInternalServerError)
 		return
@@ -350,12 +350,12 @@ func unpackUnbindRequest(r *http.Request) (*osb.UnbindRequest, error) {
 }
 
 // UpdateHandler is the mux handler that dispatches Update requests to the
-// broker's BusinessLogic.
+// broker's Interface.
 func (s *APISurface) UpdateHandler(w http.ResponseWriter, r *http.Request) {
 	s.Metrics.Actions.WithLabelValues("update").Inc()
 
 	version := getBrokerAPIVersionFromRequest(r)
-	if err := s.BusinessLogic.ValidateBrokerAPIVersion(version); err != nil {
+	if err := s.Broker.ValidateBrokerAPIVersion(version); err != nil {
 		writeError(w, err, http.StatusPreconditionFailed)
 		return
 	}
@@ -373,7 +373,7 @@ func (s *APISurface) UpdateHandler(w http.ResponseWriter, r *http.Request) {
 		Request: r,
 	}
 
-	response, err := s.BusinessLogic.Update(request, c)
+	response, err := s.Broker.Update(request, c)
 	if err != nil {
 		writeError(w, err, http.StatusInternalServerError)
 		return

--- a/pkg/server/bind_test.go
+++ b/pkg/server/bind_test.go
@@ -91,7 +91,7 @@ func TestBind(t *testing.T) {
 			reg.MustRegister(osbMetrics)
 
 			api := &rest.APISurface{
-				BusinessLogic: &FakeBusinessLogic{
+				Broker: &FakeBroker{
 					validateAPIVersion: validateFunc,
 					bind:               tc.bindFunc,
 				},

--- a/pkg/server/catalog_test.go
+++ b/pkg/server/catalog_test.go
@@ -62,7 +62,7 @@ func TestGetCatalog(t *testing.T) {
 			reg.MustRegister(osbMetrics)
 
 			api := &rest.APISurface{
-				BusinessLogic: &FakeBusinessLogic{
+				Broker: &FakeBroker{
 					validateAPIVersion: validateFunc,
 					getCatalog:         tc.catalogFunc,
 				},

--- a/pkg/server/deprovision_test.go
+++ b/pkg/server/deprovision_test.go
@@ -132,7 +132,7 @@ func TestDeprovision(t *testing.T) {
 			}
 
 			api := &rest.APISurface{
-				BusinessLogic: &FakeBusinessLogic{
+				Broker: &FakeBroker{
 					validateAPIVersion: validateFunc,
 					deprovision:        deprovisionFunc,
 				},

--- a/pkg/server/last_operation_test.go
+++ b/pkg/server/last_operation_test.go
@@ -83,7 +83,7 @@ func TestLastOperation(t *testing.T) {
 			reg.MustRegister(osbMetrics)
 
 			api := &rest.APISurface{
-				BusinessLogic: &FakeBusinessLogic{
+				Broker: &FakeBroker{
 					validateAPIVersion: validateFunc,
 					lastOperation:      tc.lastOpFunc,
 				},

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -132,7 +132,7 @@ func TestProvision(t *testing.T) {
 			}
 
 			api := &rest.APISurface{
-				BusinessLogic: &FakeBusinessLogic{
+				Broker: &FakeBroker{
 					validateAPIVersion: validateFunc,
 					provision:          provisionFunc,
 				},

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -8,9 +8,8 @@ import (
 
 // TODO: is this more of an integration test?
 
-// BusinessLogic provides an implementation of the broker.BusinessLogic
-// interface.
-type FakeBusinessLogic struct {
+// FakeBroker provides an implementation of the broker.Interface.
+type FakeBroker struct {
 	validateAPIVersion func(string) error
 	getCatalog         func(c *broker.RequestContext) (*osb.CatalogResponse, error)
 	provision          func(pr *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error)
@@ -21,37 +20,37 @@ type FakeBusinessLogic struct {
 	update             func(request *osb.UpdateInstanceRequest, c *broker.RequestContext) (*osb.UpdateInstanceResponse, error)
 }
 
-var _ broker.BusinessLogic = &FakeBusinessLogic{}
+var _ broker.Interface = &FakeBroker{}
 
-func (b *FakeBusinessLogic) GetCatalog(c *broker.RequestContext) (*osb.CatalogResponse, error) {
+func (b *FakeBroker) GetCatalog(c *broker.RequestContext) (*osb.CatalogResponse, error) {
 	return b.getCatalog(c)
 }
 
-func (b *FakeBusinessLogic) Provision(pr *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
+func (b *FakeBroker) Provision(pr *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
 	return b.provision(pr, c)
 }
 
-func (b *FakeBusinessLogic) Deprovision(request *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
+func (b *FakeBroker) Deprovision(request *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
 	return b.deprovision(request, c)
 }
 
-func (b *FakeBusinessLogic) LastOperation(request *osb.LastOperationRequest, c *broker.RequestContext) (*osb.LastOperationResponse, error) {
+func (b *FakeBroker) LastOperation(request *osb.LastOperationRequest, c *broker.RequestContext) (*osb.LastOperationResponse, error) {
 	return b.lastOperation(request, c)
 }
 
-func (b *FakeBusinessLogic) Bind(request *osb.BindRequest, c *broker.RequestContext) (*osb.BindResponse, error) {
+func (b *FakeBroker) Bind(request *osb.BindRequest, c *broker.RequestContext) (*osb.BindResponse, error) {
 	return b.bind(request, c)
 }
 
-func (b *FakeBusinessLogic) Unbind(request *osb.UnbindRequest, c *broker.RequestContext) (*osb.UnbindResponse, error) {
+func (b *FakeBroker) Unbind(request *osb.UnbindRequest, c *broker.RequestContext) (*osb.UnbindResponse, error) {
 	return b.unbind(request, c)
 }
 
-func (b *FakeBusinessLogic) ValidateBrokerAPIVersion(version string) error {
+func (b *FakeBroker) ValidateBrokerAPIVersion(version string) error {
 	return b.validateAPIVersion(version)
 }
 
-func (b *FakeBusinessLogic) Update(request *osb.UpdateInstanceRequest, c *broker.RequestContext) (*osb.UpdateInstanceResponse, error) {
+func (b *FakeBroker) Update(request *osb.UpdateInstanceRequest, c *broker.RequestContext) (*osb.UpdateInstanceResponse, error) {
 	return b.update(request, c)
 }
 

--- a/pkg/server/unbind_test.go
+++ b/pkg/server/unbind_test.go
@@ -90,7 +90,7 @@ func TestUnbind(t *testing.T) {
 			reg.MustRegister(osbMetrics)
 
 			api := &rest.APISurface{
-				BusinessLogic: &FakeBusinessLogic{
+				Broker: &FakeBroker{
 					validateAPIVersion: validateFunc,
 					unbind:             tc.unbindFunc,
 				},

--- a/pkg/server/update_instance_test.go
+++ b/pkg/server/update_instance_test.go
@@ -106,7 +106,7 @@ func TestUpdateInstance(t *testing.T) {
 			reg.MustRegister(osbMetrics)
 
 			api := &rest.APISurface{
-				BusinessLogic: &FakeBusinessLogic{
+				Broker: &FakeBroker{
 					validateAPIVersion: validateFunc,
 					update:             tc.updateFunc,
 				},


### PR DESCRIPTION
Using the more Go idiomatic choice of broker.Interface.