### PR TITLE
adding library response types

### DIFF
--- a/pkg/broker/interface.go
+++ b/pkg/broker/interface.go
@@ -33,7 +33,7 @@ type Interface interface {
 	// For more information, see:
 	//
 	// https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#catalog-management
-	GetCatalog(c *RequestContext) (*osb.CatalogResponse, error)
+	GetCatalog(c *RequestContext) (*CatalogResponse, error)
 	// Provision encapsulates the business logic for a provision operation and
 	// returns a osb.ProvisionResponse or an error. Provisioning creates a new
 	// instance of a particular service.
@@ -53,7 +53,7 @@ type Interface interface {
 	// For more information, see:
 	//
 	// https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#provisioning
-	Provision(request *osb.ProvisionRequest, c *RequestContext) (*osb.ProvisionResponse, error)
+	Provision(request *osb.ProvisionRequest, c *RequestContext) (*ProvisionResponse, error)
 	// Deprovision encapsulates the business logic for a deprovision operation
 	// and returns a osb.DeprovisionResponse or an error. Deprovisioning deletes
 	// an instance of a service and releases the resources associated with it.
@@ -74,7 +74,7 @@ type Interface interface {
 	// For more information, see:
 	//
 	// https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#deprovisioning
-	Deprovision(request *osb.DeprovisionRequest, c *RequestContext) (*osb.DeprovisionResponse, error)
+	Deprovision(request *osb.DeprovisionRequest, c *RequestContext) (*DeprovisionResponse, error)
 	// LastOperation encapsulates the business logic for a last operation
 	// request and returns a osb.LastOperationResponse or an error.
 	// LastOperation is called when a platform checks the status of an ongoing
@@ -96,7 +96,7 @@ type Interface interface {
 	// For more information, see:
 	//
 	// https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#polling-last-operation
-	LastOperation(request *osb.LastOperationRequest, c *RequestContext) (*osb.LastOperationResponse, error)
+	LastOperation(request *osb.LastOperationRequest, c *RequestContext) (*LastOperationResponse, error)
 	// Bind encapsulates the business logic for a bind operation and returns a
 	// osb.BindResponse or an error. Binding creates a new set of credentials for
 	// a consumer to use an instance of a service. Not all services are
@@ -119,7 +119,7 @@ type Interface interface {
 	// For more information, see:
 	//
 	// https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#binding
-	Bind(request *osb.BindRequest, c *RequestContext) (*osb.BindResponse, error)
+	Bind(request *osb.BindRequest, c *RequestContext) (*BindResponse, error)
 	// Unbind encapsulates the business logic for an unbind operation and
 	// returns a osb.UnbindResponse or an error. Unbind deletes a binding and the
 	// resources associated with it.
@@ -139,7 +139,7 @@ type Interface interface {
 	// For more information, see:
 	//
 	// https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#unbinding
-	Unbind(request *osb.UnbindRequest, c *RequestContext) (*osb.UnbindResponse, error)
+	Unbind(request *osb.UnbindRequest, c *RequestContext) (*UnbindResponse, error)
 	// Update encapsulates the business logic for an update operation and
 	// returns a osb.UpdateInstanceResponse or an error. Update updates the
 	// instance.
@@ -159,7 +159,7 @@ type Interface interface {
 	// For more information, see:
 	//
 	// https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#updating-a-service-instance
-	Update(request *osb.UpdateInstanceRequest, c *RequestContext) (*osb.UpdateInstanceResponse, error)
+	Update(request *osb.UpdateInstanceRequest, c *RequestContext) (*UpdateInstanceResponse, error)
 }
 
 // RequestContext encapsulates the following parameters:

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -10,10 +10,6 @@ type CatalogResponse struct {
 // ProvisionResponse is sent as the response to a provision call.
 type ProvisionResponse struct {
 	osb.ProvisionResponse
-
-	// AlreadyReceived  is used to determine if the request was a duplicate
-	// or not. should not be sent back in the respone.
-	AlreadyReceived bool `json:"-"`
 }
 
 // UpdateInstanceResponse is sent as the response to a update call.
@@ -34,11 +30,6 @@ type LastOperationResponse struct {
 // BindResponse is sent as the response to a bind call.
 type BindResponse struct {
 	osb.BindResponse
-
-	// AlreadyReceived  is used to determine if the request was a duplicate
-	// or not. should not be sent back in the respone. This is needed for
-	// async bind.
-	AlreadyReceived bool `json:"-"`
 }
 
 // UnbindResponse is sent as the response to a bind call.

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -1,0 +1,47 @@
+package broker
+
+import osb "github.com/pmorie/go-open-service-broker-client/v2"
+
+// CatalogResponse is sent as the response to a catalog requests.
+type CatalogResponse struct {
+	osb.CatalogResponse
+}
+
+// ProvisionResponse is sent as the response to a provision call.
+type ProvisionResponse struct {
+	osb.ProvisionResponse
+
+	// AlreadyReceived  is used to determine if the request was a duplicate
+	// or not. should not be sent back in the respone.
+	AlreadyReceived bool `json:"-"`
+}
+
+// UpdateInstanceResponse is sent as the response to a update call.
+type UpdateInstanceResponse struct {
+	osb.UpdateInstanceResponse
+}
+
+// DeprovisionResponse is sent as the response to a deprovision call.
+type DeprovisionResponse struct {
+	osb.DeprovisionResponse
+}
+
+// LastOperationResponse is sent as the response to a last operation call.
+type LastOperationResponse struct {
+	osb.LastOperationResponse
+}
+
+// BindResponse is sent as the response to a bind call.
+type BindResponse struct {
+	osb.BindResponse
+
+	// AlreadyReceived  is used to determine if the request was a duplicate
+	// or not. should not be sent back in the respone. This is needed for
+	// async bind.
+	AlreadyReceived bool `json:"-"`
+}
+
+// UnbindResponse is sent as the response to a bind call.
+type UnbindResponse struct {
+	osb.UnbindResponse
+}

--- a/pkg/server/bind_test.go
+++ b/pkg/server/bind_test.go
@@ -20,7 +20,7 @@ func TestBind(t *testing.T) {
 	cases := []struct {
 		name         string
 		validateFunc func(string) error
-		bindFunc     func(req *osb.BindRequest, c *broker.RequestContext) (*osb.BindResponse, error)
+		bindFunc     func(req *osb.BindRequest, c *broker.RequestContext) (*broker.BindResponse, error)
 		response     *osb.BindResponse
 		err          error
 	}{
@@ -36,7 +36,7 @@ func TestBind(t *testing.T) {
 		},
 		{
 			name: "bind returns errors.New",
-			bindFunc: func(req *osb.BindRequest, c *broker.RequestContext) (*osb.BindResponse, error) {
+			bindFunc: func(req *osb.BindRequest, c *broker.RequestContext) (*broker.BindResponse, error) {
 				return nil, errors.New("oops")
 			},
 			err: osb.HTTPStatusCodeError{
@@ -46,7 +46,7 @@ func TestBind(t *testing.T) {
 		},
 		{
 			name: "bind returns osb.HTTPStatusCodeError",
-			bindFunc: func(req *osb.BindRequest, c *broker.RequestContext) (*osb.BindResponse, error) {
+			bindFunc: func(req *osb.BindRequest, c *broker.RequestContext) (*broker.BindResponse, error) {
 				return nil, osb.HTTPStatusCodeError{
 					StatusCode:  http.StatusBadGateway,
 					Description: strPtr("custom error"),
@@ -59,17 +59,17 @@ func TestBind(t *testing.T) {
 		},
 		{
 			name: "OK",
-			bindFunc: func(req *osb.BindRequest, c *broker.RequestContext) (*osb.BindResponse, error) {
-				return &osb.BindResponse{}, nil
+			bindFunc: func(req *osb.BindRequest, c *broker.RequestContext) (*broker.BindResponse, error) {
+				return &broker.BindResponse{}, nil
 			},
 			response: &osb.BindResponse{},
 		},
 		{
 			name: "bind check originating origin identity is passed",
-			bindFunc: func(req *osb.BindRequest, c *broker.RequestContext) (*osb.BindResponse, error) {
+			bindFunc: func(req *osb.BindRequest, c *broker.RequestContext) (*broker.BindResponse, error) {
 				if req.OriginatingIdentity != nil {
 
-					return &osb.BindResponse{}, nil
+					return &broker.BindResponse{}, nil
 				}
 				return nil, fmt.Errorf("oops")
 			},

--- a/pkg/server/catalog_test.go
+++ b/pkg/server/catalog_test.go
@@ -16,22 +16,24 @@ import (
 )
 
 func TestGetCatalog(t *testing.T) {
-	okResponse := &osb.CatalogResponse{Services: []osb.Service{
-		{
-			Name: "foo",
-		},
-	}}
+	okResponse := &broker.CatalogResponse{
+		CatalogResponse: osb.CatalogResponse{
+			Services: []osb.Service{
+				{
+					Name: "foo",
+				},
+			}}}
 
 	cases := []struct {
 		name         string
 		validateFunc func(string) error
-		catalogFunc  func(c *broker.RequestContext) (*osb.CatalogResponse, error)
-		response     *osb.CatalogResponse
+		catalogFunc  func(c *broker.RequestContext) (*broker.CatalogResponse, error)
+		response     *broker.CatalogResponse
 		err          error
 	}{
 		{
 			name: "OK",
-			catalogFunc: func(c *broker.RequestContext) (*osb.CatalogResponse, error) {
+			catalogFunc: func(c *broker.RequestContext) (*broker.CatalogResponse, error) {
 				return okResponse, nil
 			},
 			response: okResponse,
@@ -93,8 +95,7 @@ func TestGetCatalog(t *testing.T) {
 				t.Error(err)
 				return
 			}
-
-			if e, a := tc.response, actualResponse; !reflect.DeepEqual(e, a) {
+			if e, a := &tc.response.CatalogResponse, actualResponse; !reflect.DeepEqual(e, a) {
 				t.Errorf("Unexpected response\n\nExpected: %#+v\n\nGot: %#+v", e, a)
 			}
 		})

--- a/pkg/server/deprovision_test.go
+++ b/pkg/server/deprovision_test.go
@@ -20,8 +20,8 @@ func TestDeprovision(t *testing.T) {
 	cases := []struct {
 		name            string
 		validateFunc    func(string) error
-		deprovisionFunc func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error)
-		response        *osb.DeprovisionResponse
+		deprovisionFunc func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*broker.DeprovisionResponse, error)
+		response        *broker.DeprovisionResponse
 		err             error
 	}{
 		{
@@ -36,7 +36,7 @@ func TestDeprovision(t *testing.T) {
 		},
 		{
 			name: "returns errors.New",
-			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
+			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*broker.DeprovisionResponse, error) {
 				return nil, errors.New("oops")
 			},
 			err: osb.HTTPStatusCodeError{
@@ -46,17 +46,17 @@ func TestDeprovision(t *testing.T) {
 		},
 		{
 			name: "validate incoming parameters",
-			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
+			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*broker.DeprovisionResponse, error) {
 				if req.PlanID == "" {
 					return nil, errors.New("deprovision request missing plan_id query parameter")
 				}
-				return &osb.DeprovisionResponse{}, nil
+				return &broker.DeprovisionResponse{}, nil
 			},
-			response: &osb.DeprovisionResponse{},
+			response: &broker.DeprovisionResponse{},
 		},
 		{
 			name: "returns osb.HTTPStatusCodeError",
-			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
+			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*broker.DeprovisionResponse, error) {
 				return nil, osb.HTTPStatusCodeError{
 					StatusCode:  http.StatusBadGateway,
 					Description: strPtr("custom error"),
@@ -69,34 +69,42 @@ func TestDeprovision(t *testing.T) {
 		},
 		{
 			name: "returns sync",
-			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
-				return &osb.DeprovisionResponse{}, nil
+			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*broker.DeprovisionResponse, error) {
+				return &broker.DeprovisionResponse{}, nil
 			},
-			response: &osb.DeprovisionResponse{},
+			response: &broker.DeprovisionResponse{},
 		},
 		{
 			name: "returns async",
-			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
-				return &osb.DeprovisionResponse{
-					Async: true,
+			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*broker.DeprovisionResponse, error) {
+				return &broker.DeprovisionResponse{
+					DeprovisionResponse: osb.DeprovisionResponse{
+						Async: true,
+					},
 				}, nil
 			},
-			response: &osb.DeprovisionResponse{
-				Async: true,
+			response: &broker.DeprovisionResponse{
+				DeprovisionResponse: osb.DeprovisionResponse{
+					Async: true,
+				},
 			},
 		},
 		{
 			name: "check originating origin identity is passed",
-			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
+			deprovisionFunc: func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*broker.DeprovisionResponse, error) {
 				if req.OriginatingIdentity != nil {
-					return &osb.DeprovisionResponse{
-						Async: true,
+					return &broker.DeprovisionResponse{
+						DeprovisionResponse: osb.DeprovisionResponse{
+							Async: true,
+						},
 					}, nil
 				}
 				return nil, fmt.Errorf("ops")
 			},
-			response: &osb.DeprovisionResponse{
-				Async: true,
+			response: &broker.DeprovisionResponse{
+				DeprovisionResponse: osb.DeprovisionResponse{
+					Async: true,
+				},
 			},
 		},
 	}
@@ -123,7 +131,7 @@ func TestDeprovision(t *testing.T) {
 			}
 
 			// establish that the request we got was the request we sent
-			deprovisionFunc := func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
+			deprovisionFunc := func(req *osb.DeprovisionRequest, c *broker.RequestContext) (*broker.DeprovisionResponse, error) {
 				if !reflect.DeepEqual(request, req) {
 					t.Errorf("unexpected request; expected %v, got %v", request, req)
 				}
@@ -164,7 +172,7 @@ func TestDeprovision(t *testing.T) {
 				return
 			}
 
-			if e, a := tc.response, actualResponse; !reflect.DeepEqual(e, a) {
+			if e, a := &tc.response.DeprovisionResponse, actualResponse; !reflect.DeepEqual(e, a) {
 				t.Errorf("Unexpected response\n\nExpected: %#+v\n\nGot: %#+v", e, a)
 			}
 		})

--- a/pkg/server/last_operation_test.go
+++ b/pkg/server/last_operation_test.go
@@ -19,8 +19,8 @@ func TestLastOperation(t *testing.T) {
 	cases := []struct {
 		name         string
 		validateFunc func(string) error
-		lastOpFunc   func(req *osb.LastOperationRequest, c *broker.RequestContext) (*osb.LastOperationResponse, error)
-		response     *osb.LastOperationResponse
+		lastOpFunc   func(req *osb.LastOperationRequest, c *broker.RequestContext) (*broker.LastOperationResponse, error)
+		response     *broker.LastOperationResponse
 		err          error
 	}{
 		{
@@ -35,7 +35,7 @@ func TestLastOperation(t *testing.T) {
 		},
 		{
 			name: "lastOperation returns errors.New",
-			lastOpFunc: func(req *osb.LastOperationRequest, c *broker.RequestContext) (*osb.LastOperationResponse, error) {
+			lastOpFunc: func(req *osb.LastOperationRequest, c *broker.RequestContext) (*broker.LastOperationResponse, error) {
 				return nil, errors.New("oops")
 			},
 			err: osb.HTTPStatusCodeError{
@@ -45,7 +45,7 @@ func TestLastOperation(t *testing.T) {
 		},
 		{
 			name: "lastOperation returns osb.HTTPStatusCodeError",
-			lastOpFunc: func(req *osb.LastOperationRequest, c *broker.RequestContext) (*osb.LastOperationResponse, error) {
+			lastOpFunc: func(req *osb.LastOperationRequest, c *broker.RequestContext) (*broker.LastOperationResponse, error) {
 				return nil, osb.HTTPStatusCodeError{
 					StatusCode:  http.StatusBadGateway,
 					Description: strPtr("custom error"),
@@ -58,13 +58,16 @@ func TestLastOperation(t *testing.T) {
 		},
 		{
 			name: "OK",
-			lastOpFunc: func(req *osb.LastOperationRequest, c *broker.RequestContext) (*osb.LastOperationResponse, error) {
-				return &osb.LastOperationResponse{
-					State: osb.StateSucceeded,
-				}, nil
+			lastOpFunc: func(req *osb.LastOperationRequest, c *broker.RequestContext) (*broker.LastOperationResponse, error) {
+				return &broker.LastOperationResponse{
+					LastOperationResponse: osb.LastOperationResponse{
+						State: osb.StateSucceeded,
+					}}, nil
 			},
-			response: &osb.LastOperationResponse{
-				State: osb.StateSucceeded,
+			response: &broker.LastOperationResponse{
+				LastOperationResponse: osb.LastOperationResponse{
+					State: osb.StateSucceeded,
+				},
 			},
 		},
 	}
@@ -117,7 +120,7 @@ func TestLastOperation(t *testing.T) {
 				return
 			}
 
-			if e, a := tc.response, actualResponse; !reflect.DeepEqual(e, a) {
+			if e, a := &tc.response.LastOperationResponse, actualResponse; !reflect.DeepEqual(e, a) {
 				t.Errorf("Unexpected response\n\nExpected: %#+v\n\nGot: %#+v", e, a)
 			}
 		})

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -19,8 +19,8 @@ func TestProvision(t *testing.T) {
 	cases := []struct {
 		name          string
 		validateFunc  func(string) error
-		provisionFunc func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error)
-		response      *osb.ProvisionResponse
+		provisionFunc func(req *osb.ProvisionRequest, c *broker.RequestContext) (*broker.ProvisionResponse, error)
+		response      *broker.ProvisionResponse
 		err           error
 	}{
 		{
@@ -35,7 +35,7 @@ func TestProvision(t *testing.T) {
 		},
 		{
 			name: "returns errors.New",
-			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
+			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*broker.ProvisionResponse, error) {
 				return nil, errors.New("oops")
 			},
 			err: osb.HTTPStatusCodeError{
@@ -45,7 +45,7 @@ func TestProvision(t *testing.T) {
 		},
 		{
 			name: "returns osb.HTTPStatusCodeError",
-			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
+			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*broker.ProvisionResponse, error) {
 				return nil, osb.HTTPStatusCodeError{
 					StatusCode:  http.StatusBadGateway,
 					Description: strPtr("custom error"),
@@ -58,44 +58,50 @@ func TestProvision(t *testing.T) {
 		},
 		{
 			name: "returns sync",
-			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
-				return &osb.ProvisionResponse{
+			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*broker.ProvisionResponse, error) {
+				return &broker.ProvisionResponse{
+					ProvisionResponse: osb.ProvisionResponse{
+						DashboardURL: strPtr("my.service.to/12345"),
+					}}, nil
+			},
+			response: &broker.ProvisionResponse{
+				ProvisionResponse: osb.ProvisionResponse{
 					DashboardURL: strPtr("my.service.to/12345"),
-				}, nil
-			},
-			response: &osb.ProvisionResponse{
-				DashboardURL: strPtr("my.service.to/12345"),
-			},
+				}},
 		},
 		{
 			name: "returns async",
-			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
-				return &osb.ProvisionResponse{
+			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*broker.ProvisionResponse, error) {
+				return &broker.ProvisionResponse{
+					ProvisionResponse: osb.ProvisionResponse{
+						Async:        true,
+						DashboardURL: strPtr("my.service.to/12345"),
+					}}, nil
+			},
+			response: &broker.ProvisionResponse{
+				ProvisionResponse: osb.ProvisionResponse{
 					Async:        true,
 					DashboardURL: strPtr("my.service.to/12345"),
-				}, nil
-			},
-			response: &osb.ProvisionResponse{
-				Async:        true,
-				DashboardURL: strPtr("my.service.to/12345"),
-			},
+				}},
 		},
 		{
 			name: "check originating origin identity is passed",
-			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
+			provisionFunc: func(req *osb.ProvisionRequest, c *broker.RequestContext) (*broker.ProvisionResponse, error) {
 				if req.OriginatingIdentity != nil {
 
-					return &osb.ProvisionResponse{
-						Async:        true,
-						DashboardURL: strPtr("my.service.to/12345"),
-					}, nil
+					return &broker.ProvisionResponse{
+						ProvisionResponse: osb.ProvisionResponse{
+							Async:        true,
+							DashboardURL: strPtr("my.service.to/12345"),
+						}}, nil
 				}
 				return nil, errors.New("oops")
 			},
-			response: &osb.ProvisionResponse{
-				Async:        true,
-				DashboardURL: strPtr("my.service.to/12345"),
-			},
+			response: &broker.ProvisionResponse{
+				ProvisionResponse: osb.ProvisionResponse{
+					Async:        true,
+					DashboardURL: strPtr("my.service.to/12345"),
+				}},
 		},
 	}
 
@@ -123,7 +129,7 @@ func TestProvision(t *testing.T) {
 			}
 
 			// establish that the request we got was the request we sent
-			provisionFunc := func(req *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
+			provisionFunc := func(req *osb.ProvisionRequest, c *broker.RequestContext) (*broker.ProvisionResponse, error) {
 				if !reflect.DeepEqual(request, req) {
 					t.Errorf("unexpected request; expected %v, got %v", request, req)
 				}
@@ -164,7 +170,7 @@ func TestProvision(t *testing.T) {
 				return
 			}
 
-			if e, a := tc.response, actualResponse; !reflect.DeepEqual(e, a) {
+			if e, a := &tc.response.ProvisionResponse, actualResponse; !reflect.DeepEqual(e, a) {
 				t.Errorf("Unexpected response\n\nExpected: %#+v\n\nGot: %#+v", e, a)
 			}
 		})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -11,38 +11,38 @@ import (
 // FakeBroker provides an implementation of the broker.Interface.
 type FakeBroker struct {
 	validateAPIVersion func(string) error
-	getCatalog         func(c *broker.RequestContext) (*osb.CatalogResponse, error)
-	provision          func(pr *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error)
-	deprovision        func(request *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error)
-	lastOperation      func(request *osb.LastOperationRequest, c *broker.RequestContext) (*osb.LastOperationResponse, error)
-	bind               func(request *osb.BindRequest, c *broker.RequestContext) (*osb.BindResponse, error)
-	unbind             func(request *osb.UnbindRequest, c *broker.RequestContext) (*osb.UnbindResponse, error)
-	update             func(request *osb.UpdateInstanceRequest, c *broker.RequestContext) (*osb.UpdateInstanceResponse, error)
+	getCatalog         func(c *broker.RequestContext) (*broker.CatalogResponse, error)
+	provision          func(pr *osb.ProvisionRequest, c *broker.RequestContext) (*broker.ProvisionResponse, error)
+	deprovision        func(request *osb.DeprovisionRequest, c *broker.RequestContext) (*broker.DeprovisionResponse, error)
+	lastOperation      func(request *osb.LastOperationRequest, c *broker.RequestContext) (*broker.LastOperationResponse, error)
+	bind               func(request *osb.BindRequest, c *broker.RequestContext) (*broker.BindResponse, error)
+	unbind             func(request *osb.UnbindRequest, c *broker.RequestContext) (*broker.UnbindResponse, error)
+	update             func(request *osb.UpdateInstanceRequest, c *broker.RequestContext) (*broker.UpdateInstanceResponse, error)
 }
 
 var _ broker.Interface = &FakeBroker{}
 
-func (b *FakeBroker) GetCatalog(c *broker.RequestContext) (*osb.CatalogResponse, error) {
+func (b *FakeBroker) GetCatalog(c *broker.RequestContext) (*broker.CatalogResponse, error) {
 	return b.getCatalog(c)
 }
 
-func (b *FakeBroker) Provision(pr *osb.ProvisionRequest, c *broker.RequestContext) (*osb.ProvisionResponse, error) {
+func (b *FakeBroker) Provision(pr *osb.ProvisionRequest, c *broker.RequestContext) (*broker.ProvisionResponse, error) {
 	return b.provision(pr, c)
 }
 
-func (b *FakeBroker) Deprovision(request *osb.DeprovisionRequest, c *broker.RequestContext) (*osb.DeprovisionResponse, error) {
+func (b *FakeBroker) Deprovision(request *osb.DeprovisionRequest, c *broker.RequestContext) (*broker.DeprovisionResponse, error) {
 	return b.deprovision(request, c)
 }
 
-func (b *FakeBroker) LastOperation(request *osb.LastOperationRequest, c *broker.RequestContext) (*osb.LastOperationResponse, error) {
+func (b *FakeBroker) LastOperation(request *osb.LastOperationRequest, c *broker.RequestContext) (*broker.LastOperationResponse, error) {
 	return b.lastOperation(request, c)
 }
 
-func (b *FakeBroker) Bind(request *osb.BindRequest, c *broker.RequestContext) (*osb.BindResponse, error) {
+func (b *FakeBroker) Bind(request *osb.BindRequest, c *broker.RequestContext) (*broker.BindResponse, error) {
 	return b.bind(request, c)
 }
 
-func (b *FakeBroker) Unbind(request *osb.UnbindRequest, c *broker.RequestContext) (*osb.UnbindResponse, error) {
+func (b *FakeBroker) Unbind(request *osb.UnbindRequest, c *broker.RequestContext) (*broker.UnbindResponse, error) {
 	return b.unbind(request, c)
 }
 
@@ -50,7 +50,7 @@ func (b *FakeBroker) ValidateBrokerAPIVersion(version string) error {
 	return b.validateAPIVersion(version)
 }
 
-func (b *FakeBroker) Update(request *osb.UpdateInstanceRequest, c *broker.RequestContext) (*osb.UpdateInstanceResponse, error) {
+func (b *FakeBroker) Update(request *osb.UpdateInstanceRequest, c *broker.RequestContext) (*broker.UpdateInstanceResponse, error) {
 	return b.update(request, c)
 }
 

--- a/pkg/server/unbind_test.go
+++ b/pkg/server/unbind_test.go
@@ -20,8 +20,8 @@ func TestUnbind(t *testing.T) {
 	cases := []struct {
 		name         string
 		validateFunc func(string) error
-		unbindFunc   func(req *osb.UnbindRequest, c *broker.RequestContext) (*osb.UnbindResponse, error)
-		response     *osb.UnbindResponse
+		unbindFunc   func(req *osb.UnbindRequest, c *broker.RequestContext) (*broker.UnbindResponse, error)
+		response     *broker.UnbindResponse
 		err          error
 	}{
 		{
@@ -36,7 +36,7 @@ func TestUnbind(t *testing.T) {
 		},
 		{
 			name: "unbind returns errors.New",
-			unbindFunc: func(req *osb.UnbindRequest, c *broker.RequestContext) (*osb.UnbindResponse, error) {
+			unbindFunc: func(req *osb.UnbindRequest, c *broker.RequestContext) (*broker.UnbindResponse, error) {
 				return nil, errors.New("oops")
 			},
 			err: osb.HTTPStatusCodeError{
@@ -46,7 +46,7 @@ func TestUnbind(t *testing.T) {
 		},
 		{
 			name: "unbind returns osb.HTTPStatusCodeError",
-			unbindFunc: func(req *osb.UnbindRequest, c *broker.RequestContext) (*osb.UnbindResponse, error) {
+			unbindFunc: func(req *osb.UnbindRequest, c *broker.RequestContext) (*broker.UnbindResponse, error) {
 				return nil, osb.HTTPStatusCodeError{
 					StatusCode:  http.StatusBadGateway,
 					Description: strPtr("custom error"),
@@ -59,20 +59,20 @@ func TestUnbind(t *testing.T) {
 		},
 		{
 			name: "OK",
-			unbindFunc: func(req *osb.UnbindRequest, c *broker.RequestContext) (*osb.UnbindResponse, error) {
-				return &osb.UnbindResponse{}, nil
+			unbindFunc: func(req *osb.UnbindRequest, c *broker.RequestContext) (*broker.UnbindResponse, error) {
+				return &broker.UnbindResponse{}, nil
 			},
-			response: &osb.UnbindResponse{},
+			response: &broker.UnbindResponse{},
 		},
 		{
 			name: "unbind check originating origin identity is passed",
-			unbindFunc: func(req *osb.UnbindRequest, c *broker.RequestContext) (*osb.UnbindResponse, error) {
+			unbindFunc: func(req *osb.UnbindRequest, c *broker.RequestContext) (*broker.UnbindResponse, error) {
 				if req.OriginatingIdentity != nil {
-					return &osb.UnbindResponse{}, nil
+					return &broker.UnbindResponse{}, nil
 				}
 				return nil, fmt.Errorf("oops")
 			},
-			response: &osb.UnbindResponse{},
+			response: &broker.UnbindResponse{},
 		},
 	}
 
@@ -132,7 +132,7 @@ func TestUnbind(t *testing.T) {
 				return
 			}
 
-			if e, a := tc.response, actualResponse; !reflect.DeepEqual(e, a) {
+			if e, a := &tc.response.UnbindResponse, actualResponse; !reflect.DeepEqual(e, a) {
 				t.Errorf("Unexpected response\n\nExpected: %#+v\n\nGot: %#+v", e, a)
 			}
 		})

--- a/pkg/server/update_instance_test.go
+++ b/pkg/server/update_instance_test.go
@@ -20,7 +20,7 @@ func TestUpdateInstance(t *testing.T) {
 	cases := []struct {
 		name         string
 		validateFunc func(string) error
-		updateFunc   func(req *osb.UpdateInstanceRequest, c *broker.RequestContext) (*osb.UpdateInstanceResponse, error)
+		updateFunc   func(req *osb.UpdateInstanceRequest, c *broker.RequestContext) (*broker.UpdateInstanceResponse, error)
 		response     *osb.UpdateInstanceResponse
 		err          error
 	}{
@@ -36,7 +36,7 @@ func TestUpdateInstance(t *testing.T) {
 		},
 		{
 			name: "update returns errors.New",
-			updateFunc: func(req *osb.UpdateInstanceRequest, c *broker.RequestContext) (*osb.UpdateInstanceResponse, error) {
+			updateFunc: func(req *osb.UpdateInstanceRequest, c *broker.RequestContext) (*broker.UpdateInstanceResponse, error) {
 				return nil, errors.New("oops")
 			},
 			err: osb.HTTPStatusCodeError{
@@ -46,7 +46,7 @@ func TestUpdateInstance(t *testing.T) {
 		},
 		{
 			name: "update returns osb.HTTPStatusCodeError",
-			updateFunc: func(req *osb.UpdateInstanceRequest, c *broker.RequestContext) (*osb.UpdateInstanceResponse, error) {
+			updateFunc: func(req *osb.UpdateInstanceRequest, c *broker.RequestContext) (*broker.UpdateInstanceResponse, error) {
 				return nil, osb.HTTPStatusCodeError{
 					StatusCode:  http.StatusBadGateway,
 					Description: strPtr("custom error"),
@@ -59,17 +59,18 @@ func TestUpdateInstance(t *testing.T) {
 		},
 		{
 			name: "update returns sync",
-			updateFunc: func(req *osb.UpdateInstanceRequest, c *broker.RequestContext) (*osb.UpdateInstanceResponse, error) {
-				return &osb.UpdateInstanceResponse{}, nil
+			updateFunc: func(req *osb.UpdateInstanceRequest, c *broker.RequestContext) (*broker.UpdateInstanceResponse, error) {
+				return &broker.UpdateInstanceResponse{}, nil
 			},
 			response: &osb.UpdateInstanceResponse{},
 		},
 		{
 			name: "update returns async",
-			updateFunc: func(req *osb.UpdateInstanceRequest, c *broker.RequestContext) (*osb.UpdateInstanceResponse, error) {
-				return &osb.UpdateInstanceResponse{
-					Async: true,
-				}, nil
+			updateFunc: func(req *osb.UpdateInstanceRequest, c *broker.RequestContext) (*broker.UpdateInstanceResponse, error) {
+				return &broker.UpdateInstanceResponse{
+					UpdateInstanceResponse: osb.UpdateInstanceResponse{
+						Async: true,
+					}}, nil
 			},
 			response: &osb.UpdateInstanceResponse{
 				Async: true,
@@ -77,12 +78,13 @@ func TestUpdateInstance(t *testing.T) {
 		},
 		{
 			name: "update check originating origin identity is passed",
-			updateFunc: func(req *osb.UpdateInstanceRequest, c *broker.RequestContext) (*osb.UpdateInstanceResponse, error) {
+			updateFunc: func(req *osb.UpdateInstanceRequest, c *broker.RequestContext) (*broker.UpdateInstanceResponse, error) {
 				if req.OriginatingIdentity != nil {
 
-					return &osb.UpdateInstanceResponse{
-						Async: true,
-					}, nil
+					return &broker.UpdateInstanceResponse{
+						UpdateInstanceResponse: osb.UpdateInstanceResponse{
+							Async: true,
+						}}, nil
 				}
 				return nil, fmt.Errorf("oops")
 			},


### PR DESCRIPTION
This is in regards to #13. 

This creates the new types of the responses that the `broker.Interface` will eventually use.

cc @pmorie @jmrodri 