### PR TITLE
Unit test for unpackUpdateRequest

### DIFF
--- a/pkg/rest/apisurface.go
+++ b/pkg/rest/apisurface.go
@@ -391,7 +391,8 @@ func (s *APISurface) UpdateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	request, err := unpackUpdateRequest(r)
+	v := mux.Vars(r)
+	request, err := unpackUpdateRequest(r, v)
 	if err != nil {
 		s.writeError(w, err, http.StatusInternalServerError)
 		return
@@ -418,13 +419,12 @@ func (s *APISurface) UpdateHandler(w http.ResponseWriter, r *http.Request) {
 	s.writeResponse(w, status, response)
 }
 
-func unpackUpdateRequest(r *http.Request) (*osb.UpdateInstanceRequest, error) {
+func unpackUpdateRequest(r *http.Request, vars map[string]string) (*osb.UpdateInstanceRequest, error) {
 	osbRequest := &osb.UpdateInstanceRequest{}
 	if err := unmarshalRequestBody(r, osbRequest); err != nil {
 		return nil, err
 	}
 
-	vars := mux.Vars(r)
 	osbRequest.InstanceID = vars[osb.VarKeyInstanceID]
 
 	asyncQueryParamVal := r.FormValue(osb.AcceptsIncomplete)

--- a/pkg/rest/apisurface_test.go
+++ b/pkg/rest/apisurface_test.go
@@ -1,0 +1,64 @@
+package rest
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUnpackUpdateRequest(t *testing.T) {
+	instanceID := "i1234"
+	serviceID := "s1234"
+	planID := "p1234"
+	acceptsIncomplete := true
+
+	fakeUpdateReq := createFakeUpdateRequest(serviceID, planID, acceptsIncomplete)
+	unpackReq, err := unpackUpdateRequest(fakeUpdateReq, map[string]string{"instance_id": instanceID})
+	if err != nil {
+		t.Fatalf("Unpacking update request: %v", err)
+	}
+
+	if unpackReq.InstanceID != instanceID {
+		t.Fatalf("InstanceID was unpacked unsuccessfully. Expecting %s got %s", instanceID, unpackReq.InstanceID)
+	}
+
+	if unpackReq.ServiceID != serviceID {
+		t.Fatalf("PlanID was unpacked unsuccessfully. Expecting %s got %s", serviceID, unpackReq.ServiceID)
+	}
+
+	if *unpackReq.PlanID != planID {
+		t.Fatalf("PlanID was unpacked unsuccessfully. Expecting %s got %s", planID, *unpackReq.PlanID)
+	}
+
+	if unpackReq.AcceptsIncomplete != acceptsIncomplete {
+		t.Fatalf("AcceptsIncomplete was unpacked unsuccessfully. Expecting %t got %t", acceptsIncomplete, unpackReq.AcceptsIncomplete)
+	}
+}
+
+func createFakeUpdateRequest(s, p string, a bool) *http.Request {
+	data := fmt.Sprintf(`{
+  "context": {
+    "platform": "kubernetes",
+    "some_field": "some-contextual-data"
+  },
+  "service_id": "%s",
+  "plan_id": "%s",
+  "parameters": {
+    "parameter1": 1,
+    "parameter2": "foo"
+  },
+  "previous_values": {
+    "plan_id": "old-plan-id-here",
+    "service_id": "service-id-here",
+    "organization_id": "org-guid-here",
+    "space_id": "space-guid-here"
+  }
+}`, s, p)
+
+	r := bytes.NewBufferString(data)
+	uri := fmt.Sprintf("/v2/service_instances/i1234?accepts_incomplete=%t", a)
+
+	return httptest.NewRequest("PATCH", uri, r)
+}


### PR DESCRIPTION
As promised (https://github.com/pmorie/osb-broker-lib/pull/38) here is the unit test for the unpackUpdateRequest function. Let me know what you think about it? If you agree with it, we could add more tests scenarios, as well as test other unpack methods?

Had to make a change to the unpackUpdateRequest method, due to the mux.Vars holding global state, we instead pass the vars to the unpackUpdateRequest, and that way make it easier to test.

cc @pmorie @n3wscott @shawn-hurley @jmrodri 