### PR TITLE
apisurface: Set PlanID and ServiceID in UnbindRequest

### DIFF
--- a/pkg/rest/apisurface.go
+++ b/pkg/rest/apisurface.go
@@ -340,7 +340,8 @@ func (s *APISurface) UnbindHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	request, err := unpackUnbindRequest(r)
+	v := mux.Vars(r)
+	request, err := unpackUnbindRequest(r, v)
 	if err != nil {
 		s.writeError(w, err, http.StatusInternalServerError)
 		return
@@ -362,10 +363,9 @@ func (s *APISurface) UnbindHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // unpackUnbindRequest unpacks an osb request from the given HTTP request.
-func unpackUnbindRequest(r *http.Request) (*osb.UnbindRequest, error) {
+func unpackUnbindRequest(r *http.Request, vars map[string]string) (*osb.UnbindRequest, error) {
 	osbRequest := &osb.UnbindRequest{}
 
-	vars := mux.Vars(r)
 	osbRequest.InstanceID = vars[osb.VarKeyInstanceID]
 	osbRequest.BindingID = vars[osb.VarKeyBindingID]
 

--- a/pkg/rest/apisurface.go
+++ b/pkg/rest/apisurface.go
@@ -369,6 +369,11 @@ func unpackUnbindRequest(r *http.Request) (*osb.UnbindRequest, error) {
 	osbRequest.InstanceID = vars[osb.VarKeyInstanceID]
 	osbRequest.BindingID = vars[osb.VarKeyBindingID]
 
+	// plan_id and service_id are set in the query string parameters and thus need to
+	// be obtained differently than instance_id and binding_id.
+	osbRequest.PlanID = r.FormValue(osb.VarKeyPlanID)
+	osbRequest.ServiceID = r.FormValue(osb.VarKeyServiceID)
+
 	identity, err := retrieveOriginatingIdentity(r)
 	// This could be not found because platforms may support the feature
 	// but are not guaranteed to.

--- a/pkg/rest/apisurface_test.go
+++ b/pkg/rest/apisurface_test.go
@@ -62,3 +62,42 @@ func createFakeUpdateRequest(s, p string, a bool) *http.Request {
 
 	return httptest.NewRequest("PATCH", uri, r)
 }
+
+func TestUnpackUnbindRequest(t *testing.T) {
+	instanceID := "i1234"
+	serviceID := "s1234"
+	planID := "p1234"
+	bindingID := "b1234"
+
+	fakeUnbindReq := createFakeUnbindRequest(serviceID, planID, instanceID, bindingID)
+	unpackReq, err := unpackUnbindRequest(fakeUnbindReq, map[string]string{
+		"instance_id": instanceID,
+		"binding_id":  bindingID,
+	})
+	if err != nil {
+		t.Fatalf("Unpacking unbind request: %v", err)
+	}
+
+	if unpackReq.InstanceID != instanceID {
+		t.Fatalf("InstanceID was unpacked unsuccessfully. Expecting %s got %s", instanceID, unpackReq.InstanceID)
+	}
+
+	if unpackReq.ServiceID != serviceID {
+		t.Fatalf("ServiceID was unpacked unsuccessfully. Expecting %s got %s", serviceID, unpackReq.ServiceID)
+	}
+
+	if unpackReq.PlanID != planID {
+		t.Fatalf("PlanID was unpacked unsuccessfully. Expecting %s got %s", planID, unpackReq.PlanID)
+	}
+
+	if unpackReq.BindingID != bindingID {
+		t.Fatalf("BindingID was unpacked unsuccessfully. Expecting %s got %s", bindingID, unpackReq.BindingID)
+	}
+}
+
+func createFakeUnbindRequest(s, p, i, b string) *http.Request {
+	body := bytes.NewBufferString("")
+	uri := fmt.Sprintf("/v2/service_instances/%s/service_bindings/%s?plan_id=%s&service_id=%s", i, b, p, s)
+
+	return httptest.NewRequest("DELETE", uri, body)
+}


### PR DESCRIPTION
`plan_id` and `service_id` are available as query parameters in an unbind request according to the OSB spec: https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/spec.md#parameters-3

There is a change in the function signature and usage of `unpackUnbindRequest` similar to that of `unpackUpdateRequest` to make testing easier. See commit 2445295453a69eabd43ea408124de3f1e118840c for more information.

This PR also fixes #43 